### PR TITLE
Remove useless variable assignment.

### DIFF
--- a/lib/coinmarketcap.rb
+++ b/lib/coinmarketcap.rb
@@ -43,7 +43,7 @@ module Coinmarketcap
           price_bundle[:avg] = ( price_bundle[:high] + price_bundle[:low] ) / 2.0
           prices << price_bundle
         end
-      rescue => error
+      rescue
         next
       end
     end


### PR DESCRIPTION
The rescued error is assigned to variable `error`, but is never used.